### PR TITLE
[BUGFIX] #5 Fixed RepositoryCommandError on empty git repository

### DIFF
--- a/repositoryhandler/backends/git.py
+++ b/repositoryhandler/backends/git.py
@@ -21,7 +21,7 @@ import re
 
 from repositoryhandler.Command import Command, CommandError
 from repositoryhandler.backends import Repository,\
-     RepositoryInvalidWorkingCopy, register_backend
+     RepositoryInvalidWorkingCopy, register_backend, RepositoryCommandError
 from repositoryhandler.backends.watchers import *
 
 
@@ -286,7 +286,10 @@ class GitRepository(Repository):
             cmd.append(uri)
 
         command = Command(cmd, cwd, env={'PAGER': ''})
-        self._run_command(command, LOG)
+        try:
+            self._run_command(command, LOG)
+        except RepositoryCommandError:
+            pass
 
     def rlog(self, module=None, rev=None, files=None):
         # Not supported by Git


### PR DESCRIPTION
If an empty git repository (without any commits) will be analyzed repositoryhandler fails because the command
git log --all --topo-order --pretty=fuller --parents --name-status -M -C --decorate=full origin
fails with exit code 128

See #5 for more information
