### PR TITLE
implemented is-ancestor for git 1.8+

### DIFF
--- a/repositoryhandler/backends/__init__.py
+++ b/repositoryhandler/backends/__init__.py
@@ -125,7 +125,7 @@ class Repository:
         '''Return the last revision'''
         raise NotImplementedError
 
-    def is_ancestor(self, rev1, rev2):
+    def is_ancestor(self, uri, rev1, rev2):
         '''Decide if rev1 is an ancestor of rev2'''
         raise  NotImplementedError
 

--- a/repositoryhandler/backends/git.py
+++ b/repositoryhandler/backends/git.py
@@ -434,12 +434,13 @@ class GitRepository(Repository):
 
         return out.strip('\n\t ')
 
-    def is_ancestor(self, rev1, rev2):
+    def is_ancestor(self, uri, rev1, rev2):
+        self._check_uri(uri)
         version = self._get_git_version()
         if version[0] >= 1 and version[1] >= 8:
             # 'git merge-base --is-ancestor' is only supported after 1.8
             cmd = ['git', 'merge-base', '--is-ancestor', rev1, rev2]
-            command = Command(cmd, self.uri, env={'PAGER': ''})
+            command = Command(cmd, uri, env={'PAGER': ''})
             try:
                 command.run()
                 return True


### PR DESCRIPTION
Deciding whether a commit precedes another  not easy due to the non-linear development in Git. Dates are not reliable anymore, nor is the order they appear in the log. This PR makes used of 'git merge-base --is-ancestor` introduced in Git 1.8 to decide that. I am not sure whether we should support earlier versions of Git.

@andygrunwald, @sduenas, comments?
