### PR TITLE
Added .idea to .gitignore file to work with PyCharm IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.status
 configure
 install-sh
 *.pc
+.idea
 missing
 py-compile
 INSTALL


### PR DESCRIPTION
The company JetBrains got really nice IDEs for various programming languages.
One IDE is PyCharm, the Python IDE.

I use the community version of PyCharm for Python development: http://www.jetbrains.com/pycharm/
If you open a folder / project with this IDE, the program will create a .idea folder to store meta information.

This PR just add this .idea folder to .gitignore file
