### PR TITLE
Add -c option to git-log

### DIFF
--- a/repositoryhandler/backends/git.py
+++ b/repositoryhandler/backends/git.py
@@ -276,7 +276,7 @@ class GitRepository(Repository):
             cwd = os.getcwd()
 
         cmd = ['git', 'log', '--all', '--topo-order', '--pretty=fuller',
-               '--parents', '--name-status', '-M', '-C']
+               '--parents', '--name-status', '-M', '-C', '-c']
 
         # Git < 1.6.4 -> --decorate
         # Git = 1.6.4 -> broken


### PR DESCRIPTION
According to git documentation:

```
   -c
       With this option, diff output for a merge commit shows the differences from each of the
       parents to the merge result simultaneously instead of showing pairwise diff between a parent
       and the result one at a time. Furthermore, it lists only files which were modified from all
       parents.
```

Actions in merge commit should only contains files modified in both parents, otherwise, the action will be duplicated.

@sduenas what do you think?
