### PR TITLE
avoid parsing remote branches when gitref=master is specified

### DIFF
--- a/repositoryhandler/backends/git.py
+++ b/repositoryhandler/backends/git.py
@@ -293,19 +293,19 @@ class GitRepository(Repository):
         else:
             cmd.append('--decorate=full')
 
-        try:
-            get_config(uri, 'remote.origin.url')
-
-            if major <= 1 and minor < 8:
-                cmd.append('origin')
-            else:
-                cmd.append('--remotes=origin')
-        except CommandError:
-            pass
 
         if gitref:
             cmd.append(gitref)
         else:
+            try:
+                get_config(uri, 'remote.origin.url')
+
+                if major <= 1 and minor < 8:
+                    cmd.append('origin')
+                else:
+                    cmd.append('--remotes=origin')
+            except CommandError:
+                pass
             cmd.append('--all')
 
         if rev is not None:


### PR DESCRIPTION
@maelick @jgbarah I am actually not sure about what the best behavior should be. In this pull request, I remove the `--remotes` totally. Another option would be having `--remotes=origin/master`. In any case, having `--remotes=origin` defeats the purpose of `gitref`, as it will parse all branches on `origin`
